### PR TITLE
Add monthly history and trend charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A simple browser-based finance tracker for couples. CoupleCash lets you record i
 - View a sortable transaction list and delete entries
 - See total income, total expenses and balance at a glance
 - Placeholder pie chart for expenses by category (Chart.js)
+- Line chart of income vs expenses over time with average spending indicator
+- Monthly history view with quick summaries
 - Responsive, mobile-friendly design
 
 ## Setup & Usage

--- a/index.html
+++ b/index.html
@@ -53,6 +53,18 @@
       </div>
     </section>
 
+    <!-- History View -->
+    <section id="history">
+      <h2>History</h2>
+      <select id="month-select"></select>
+      <div class="summary-grid">
+        <div class="summary-item">Income: <span id="history-income">$0.00</span></div>
+        <div class="summary-item">Expenses: <span id="history-expenses">$0.00</span></div>
+        <div class="summary-item">Balance: <span id="history-balance">$0.00</span></div>
+        <div class="summary-item">Savings: <span id="history-savings">$0.00</span></div>
+      </div>
+    </section>
+
     <!-- Transactions List -->
     <section id="transactions">
       <h2>Transactions</h2>
@@ -76,6 +88,12 @@
     <section id="chart-section">
       <h2>Expenses by Category</h2>
       <canvas id="expense-chart" width="300" height="300"></canvas>
+    </section>
+
+    <!-- Trend Chart -->
+    <section id="trend-section">
+      <h2>Income vs Expenses</h2>
+      <canvas id="trend-chart" width="300" height="200"></canvas>
     </section>
   </main>
 

--- a/style.css
+++ b/style.css
@@ -122,6 +122,16 @@ button:hover {
   margin-top: 1rem;
 }
 
+#trend-section canvas {
+  max-width: 100%;
+  margin-top: 1rem;
+}
+
+/* History */
+#history select {
+  margin-bottom: 1rem;
+}
+
 @media (max-width: 600px) {
   .form-group {
     flex: 1 1 100%;


### PR DESCRIPTION
## Summary
- add drop-down history view and trend chart canvas in UI
- style new history and trend sections
- compute monthly summaries and update localStorage
- render monthly history dropdown, summary and Chart.js line chart
- document new features in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eb84e8a74832bb8f541589ab0ae24