### PR TITLE
Add savings allocation field and tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A simple browser-based finance tracker for couples. CoupleCash lets you record i
 - View a sortable transaction list and delete entries
 - See total income, total expenses and balance at a glance
 - Placeholder pie chart for expenses by category (Chart.js)
+- Track a monthly savings goal with progress from income allocations
 - Responsive, mobile-friendly design
 
 ## Setup & Usage
@@ -15,7 +16,8 @@ A simple browser-based finance tracker for couples. CoupleCash lets you record i
 1. Clone or download this repository.
 2. Open `index.html` in your browser, or host the project with GitHub Pages.
 3. Use the **Add Transaction** form to record income or expenses.
-4. Your data is saved automatically in the browser and will be restored when you revisit the page.
+4. When adding income you may specify a **Savings Allocation** amount. This value counts toward your monthly savings goal.
+5. Your data is saved automatically in the browser and will be restored when you revisit the page.
 
 ## GitHub Pages Hosting
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
           <label for="amount">Amount</label>
           <input type="number" id="amount" step="0.01" min="0" required>
         </div>
+        <div id="savings-group" class="form-group hidden">
+          <label for="savings">Savings Allocation</label>
+          <input type="number" id="savings" step="0.01" min="0">
+        </div>
         <div class="form-group">
           <label for="category">Category</label>
           <input type="text" id="category" required>

--- a/script.js
+++ b/script.js
@@ -79,12 +79,26 @@ function updateSummary() {
   updateSavingsProgress();
 }
 
+function toggleSavingsField() {
+  const typeSelect = document.getElementById('type');
+  const group = document.getElementById('savings-group');
+  const input = document.getElementById('savings');
+  if (!typeSelect || !group) return;
+  if (typeSelect.value === 'income') {
+    group.classList.remove('hidden');
+  } else {
+    group.classList.add('hidden');
+    if (input) input.value = '';
+  }
+}
+
 // Handle form submission
 function handleFormSubmit(event) {
   event.preventDefault();
 
   const type = document.getElementById('type').value;
   const amount = parseFloat(document.getElementById('amount').value);
+  const savingsInput = document.getElementById('savings');
   const category = document.getElementById('category').value.trim();
   const date = document.getElementById('date').value;
   const notes = document.getElementById('notes').value.trim();
@@ -94,14 +108,22 @@ function handleFormSubmit(event) {
     return;
   }
 
+  let savings = 0;
+  if (type === 'income') {
+    const val = parseFloat(savingsInput.value);
+    savings = isNaN(val) ? 0 : val;
+  }
+
   const transactions = loadTransactions();
-  transactions.push({ id: Date.now(), type, amount, category, date, notes });
+  transactions.push({ id: Date.now(), type, amount, category, date, notes, savings });
   saveTransactions(transactions);
 
   renderTransactions();
   updateSummary();
   updateChart();
   event.target.reset();
+  savingsInput.value = '';
+  toggleSavingsField();
 }
 
 // Delete transaction by id
@@ -156,19 +178,16 @@ function updateSavingsProgress() {
     return d.getMonth() === month && d.getFullYear() === year;
   });
 
-  let income = 0;
-  let expenses = 0;
-  transactions.forEach(t => {
-    const amt = Number(t.amount);
-    if (t.type === 'income') income += amt; else expenses += amt;
-  });
+  const allocated = transactions
+    .filter(t => t.type === 'income')
+    .reduce((sum, t) => sum + Number(t.savings || 0), 0);
 
   const manual = loadSavingsEvents().filter(e => {
     const d = new Date(e.date);
     return d.getMonth() === month && d.getFullYear() === year;
   }).reduce((sum, e) => sum + Number(e.amount), 0);
 
-  const savings = (income - expenses) + manual;
+  const savings = allocated + manual;
 
   const progress = document.getElementById('goal-progress');
   const label = document.getElementById('progress-label');
@@ -186,6 +205,12 @@ function init() {
       deleteTransaction(e.target.dataset.id);
     }
   });
+
+  const typeSelect = document.getElementById('type');
+  if (typeSelect) {
+    typeSelect.addEventListener('change', toggleSavingsField);
+  }
+  toggleSavingsField();
 
   const setGoalBtn = document.getElementById('set-goal-btn');
   const addSavingBtn = document.getElementById('add-saving-btn');


### PR DESCRIPTION
## Summary
- allow savings allocation when adding income
- show or hide the savings field based on transaction type
- track monthly savings using allocations plus manual savings
- document the new feature

## Testing
- `pre-commit` *(fails: no configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684ec5155ee4832bb5f7a5bf668e754d