### PR TITLE
Add savings allocation field and tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A simple browser-based finance tracker for couples. CoupleCash lets you record i
 - View a sortable transaction list and delete entries
 - See total income, total expenses and balance at a glance
 - Placeholder pie chart for expenses by category (Chart.js)
+- Track a monthly savings goal with progress from income allocations and manual savings events
 - Responsive, mobile-friendly design
 
 ## Setup & Usage
@@ -15,7 +16,8 @@ A simple browser-based finance tracker for couples. CoupleCash lets you record i
 1. Clone or download this repository.
 2. Open `index.html` in your browser, or host the project with GitHub Pages.
 3. Use the **Add Transaction** form to record income or expenses.
-4. Your data is saved automatically in the browser and will be restored when you revisit the page.
+4. When adding income you may specify a **Savings Allocation** amount. This value, combined with any manual savings, counts toward your monthly savings goal.
+5. Your data is saved automatically in the browser and will be restored when you revisit the page.
 
 ## GitHub Pages Hosting
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
           <label for="amount">Amount</label>
           <input type="number" id="amount" step="0.01" min="0" required>
         </div>
+        <div id="savings-group" class="form-group hidden">
+          <label for="savings">Savings Allocation</label>
+          <input type="number" id="savings" step="0.01" min="0">
+        </div>
         <div class="form-group">
           <label for="category">Category</label>
           <input type="text" id="category" required>


### PR DESCRIPTION
## Summary
- allow savings allocation when adding income
- show or hide the savings field based on transaction type
- track monthly savings using allocations plus manual savings
- validate that savings does not exceed the income amount
- document the new feature

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec5155ee4832bb5f7a5bf668e754d